### PR TITLE
Add test description to test details for ExtentITestListenerClassAdapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.aventstack</groupId>
 	<artifactId>extentreports-testng-adapter</artifactId>
-	<version>1.2.3</version>
+	<version>1.2.4</version>
 	<name>extentreports-testng-adapter</name>
 	<url>http://extentreports.com</url>
 	<description>TestNG adapter for Extent Framework</description>

--- a/src/main/java/com/aventstack/extentreports/service/ExtentTestManager.java
+++ b/src/main/java/com/aventstack/extentreports/service/ExtentTestManager.java
@@ -91,6 +91,7 @@ public class ExtentTestManager {
     }
 
     public static synchronized void log(ITestResult result, Boolean createTestAsChild) {
+        String testDescription = result.getMethod().getDescription() == null ? "" : result.getMethod().getDescription().trim();
         String msg = "Test ";
         Status status = Status.PASS;
         switch (result.getStatus()) {
@@ -106,9 +107,14 @@ public class ExtentTestManager {
                 msg += "passed";
                 break;
         }
+        msg = createTestAsChild && !testDescription.isEmpty() ? testDescription : msg;
         if (ExtentTestManager.getTest(result) == null)
             ExtentTestManager.createMethod(result, createTestAsChild);
-        if (result.getThrowable() != null) {
+
+        if ((result.getThrowable() != null) && createTestAsChild && !testDescription.isEmpty()) {
+            if (!testDescription.isEmpty()) {
+                ExtentTestManager.getTest(result).info(testDescription);
+            }
             ExtentTestManager.getTest(result).log(status, result.getThrowable());
             return;
         }

--- a/src/test/java/com/aventstack/extentreports/adapter/ireporter/DescriptionTests.java
+++ b/src/test/java/com/aventstack/extentreports/adapter/ireporter/DescriptionTests.java
@@ -1,0 +1,32 @@
+package com.aventstack.extentreports.adapter.ireporter;
+
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import com.aventstack.extentreports.testng.listener.ExtentIReporterSuiteClassListenerAdapter;
+
+@Listeners({ExtentIReporterSuiteClassListenerAdapter.class})
+public class DescriptionTests {
+
+    @Test
+    public void passClass2() {
+        Assert.assertTrue(true);
+    }
+
+    @Test(description = "This is a test description")
+    public void passClass2Description() {
+        Assert.assertTrue(true);
+    }
+
+    @Test
+    public void failClass2() {
+        Assert.assertTrue(false);
+    }
+
+    @Test(description = "This is a test description")
+    public void failClass2Description() {
+        Assert.assertTrue(false);
+    }
+
+}

--- a/src/test/java/com/aventstack/extentreports/adapter/testlistener/DescriptionTests.java
+++ b/src/test/java/com/aventstack/extentreports/adapter/testlistener/DescriptionTests.java
@@ -1,0 +1,31 @@
+package com.aventstack.extentreports.adapter.testlistener;
+
+import com.aventstack.extentreports.testng.listener.ExtentITestListenerAdapter;
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners({ExtentITestListenerAdapter.class})
+public class DescriptionTests extends BaseDataProvider {
+
+	@Test
+	public void passClass2() {
+		Assert.assertTrue(true);
+	}
+
+	@Test(description = "This is a test description")
+	public void passClass2Description() {
+		Assert.assertTrue(true);
+	}
+
+	@Test(groups = { "functest", "checkintest" })
+	public void failClass2() {
+		Assert.assertTrue(false);
+	}
+
+	@Test(groups = { "functest", "checkintest" }, description = "This is a test description")
+	public void failClass2Description() {
+		Assert.assertTrue(false);
+	}
+	
+}

--- a/src/test/java/com/aventstack/extentreports/adapter/testlistenerclass/DescriptionTests.java
+++ b/src/test/java/com/aventstack/extentreports/adapter/testlistenerclass/DescriptionTests.java
@@ -1,0 +1,31 @@
+package com.aventstack.extentreports.adapter.testlistenerclass;
+
+import com.aventstack.extentreports.testng.listener.ExtentITestListenerClassAdapter;
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners({ExtentITestListenerClassAdapter.class})
+public class DescriptionTests extends BaseDataProvider {
+
+	@Test
+	public void passClass2() {
+		Assert.assertTrue(true);
+	}
+
+	@Test(description = "This is a test description")
+	public void passClass2Description() {
+		Assert.assertTrue(true);
+	}
+	
+	@Test(groups = { "functest", "checkintest" })
+	public void failClass2() {
+		Assert.assertTrue(false);
+	}
+
+	@Test(groups = { "functest", "checkintest" }, description = "This is a test description")
+	public void failClass2Description() {
+		Assert.assertTrue(false);
+	}
+	
+}


### PR DESCRIPTION
With current behavior of adapter test description is not displayed for each test when using ExtentITestListenerClassAdapter.
This commits adds the following functionality:

- Add test description to test details for ExtentITestListenerClassAdapter. If there is no description for the test, default value for details will be used (Test passed,Test failed or Test skipped)
- Add test description via info log when test result has a throwable. When a throwable is logged it overwrites the test details, therefore the current approach is to add another log to display the test description. @anshooarora Is there a way to have both a code/throwable and plain text on details column?
- Add a couple of tests specific for description

This will probably address issue #20

Screenshot for results:
![image](https://user-images.githubusercontent.com/44622638/160031318-88314c0e-56d5-4249-a56c-1a97694d74fa.png)


